### PR TITLE
Feature updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following scripts in `src/examples/` demonstrate common EAS interactions:
   - Run with: `yarn example:register-schema`
   - **Note:** You need to edit the script to provide a valid `schema` object.
 
-- **`get-schema.ts`**: 
+- **`fetch-schema.ts`**: 
   - Shows how to fetch the details of an existing schema using its UID.
   - Run with: `yarn example:fetch-schema`
   - **Note:** You need to edit the script to provide a valid `schemaUID`.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "example:fetch": "ts-node src/examples/get-attestation.ts",
         "example:revoke": "ts-node src/examples/revoke-attestation.ts",
         "example:register-schema": "ts-node src/examples/register-schema.ts",
-        "example:fetch-schema": "ts-node src/examples/get-schema.ts",
+        "example:fetch-schema": "ts-node src/examples/fetch-schema.ts",
         "example:save-offchain": "ts-node src/examples/save-offchain-attestation.ts",
         "example:load-offchain": "ts-node src/examples/load-offchain-attestations.ts",
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/eas-schema.ts
+++ b/src/eas-schema.ts
@@ -1,5 +1,5 @@
-import { EAS, SchemaRegistry } from "@ethereum-attestation-service/eas-sdk";
-import { ethers, Signer, Provider } from "ethers";
+import { SchemaRegistry } from "@ethereum-attestation-service/eas-sdk";
+import { ethers, Signer, isError } from "ethers";
 // Import the specific Schema Registry address
 import { EASSchemaRegistryAddress } from "./config";
 import { getProviderSigner } from "./provider"; // To get provider for read operations
@@ -19,6 +19,59 @@ export interface SchemaRecord {
     revocable: boolean;
 }
 
+
+/**
+ * Checks if a schema is already registered in the SchemaRegistry by calculating its potential UID.
+ * 
+ * @param schema The schema definition string (e.g., "uint256 eventId, bool vote").
+ * @param resolverAddress Optional: Address of a resolver contract.
+ * @param revocable Whether attestations using this schema are revocable by default.
+ * @returns The UID if the schema exists, otherwise null.
+ */
+export async function checkExistingSchema(schema: string, resolverAddress: string | undefined, revocable: boolean): Promise<string | null> {
+    // Calculate the potential UID for the schema.
+    const potentialUID = ethers.solidityPackedKeccak256(
+        ['string', 'address', 'bool'],
+        [schema, resolverAddress ?? ethers.ZeroAddress, revocable]
+    );
+
+    console.log(`\nChecking for existing schema with potential UID: ${potentialUID}...`);
+
+    // Instantiate SchemaRegistry for read operation.
+    const schemaRegistry = new SchemaRegistry(EASSchemaRegistryAddress);
+    const { provider } = getProviderSigner(); // Need provider for read operations
+    schemaRegistry.connect(provider);
+
+    try {
+        // Attempt to fetch the schema record using the calculated UID.
+        const schemaRecord = await schemaRegistry.getSchema({ uid: potentialUID });
+
+        // Check if the schema record is empty (indicates not found).
+        if (schemaRecord.uid === ethers.ZeroHash || schemaRecord.schema === "") {
+            console.log('Schema not registered yet.');
+            return null;
+        } else {
+            // Schema exists
+            console.log(`Schema already exists with UID: ${schemaRecord.uid}`);
+            console.log(`View schema at: https://sepolia.easscan.org/schema/view/${schemaRecord.uid}`);
+            return schemaRecord.uid; // Return the existing UID
+        }
+    } catch (error) {
+        // Handle cases where getSchema might fail unexpectedly.
+        // Check if it's the specific 'Schema not found' error from the SDK.
+        if (error instanceof Error && error.message === 'Schema not found') {
+            // Log a simpler message without the stack trace for this specific case.
+            console.error("Error checking existing schema: Error: Schema not found");
+        } else {
+            // Log other unexpected errors with more details.
+            console.error("Unexpected error checking existing schema:", error);
+        }
+        // Decide on error handling: return null or re-throw. Returning null aligns with "not found".
+        return null; 
+    }
+}
+
+
 /**
  * Registers a new schema on the EAS SchemaRegistry.
  * Assumes transaction.wait() directly returns the schema UID string.
@@ -37,32 +90,96 @@ export async function registerSchema(
 
     const { schema, resolverAddress, revocable } = schemaData;
 
+    // First, check if the schema already exists to avoid unnecessary transaction
+    const existingSchemaUID = await checkExistingSchema(schema, resolverAddress, revocable);
+    if (existingSchemaUID) {
+        return existingSchemaUID; // Return the existing UID if found
+    }
+
     console.log(`\nAttempting to register schema: "${schema}"...`);
     console.log(`Resolver: ${resolverAddress ?? ethers.ZeroAddress}`);
     console.log(`Revocable: ${revocable}`);
 
-    const transaction = await schemaRegistry.register({
-        schema: schema,
-        resolverAddress: resolverAddress ?? ethers.ZeroAddress, // Use ZeroAddress if no resolver
-        revocable: revocable,
-    });
+    // Wrap the transaction in a try-catch block to handle errors gracefully
+    // This can help identify issues, especially when the transaction hangs or fails
+    try {
 
-    console.log("Schema registration transaction submitted...");
+        // Setting up the transaction overrides. This is optional and can be adjusted.
+        // If you're experiencing hangs with the transaction, it might help to adjust
+        // the gas limit or other parameters. The default gas limit is usually sufficient,
+        // but you can specify it explicitly if needed.
 
-    // Wait for transaction confirmation - Assuming wait() returns the UID string directly
-    const newSchemaUID = await transaction.wait();
+        // Uncomment the following line to set an explicit gas limit if needed and other overrides
+        // the default gas limit is 21000 for simple transactions, but it can vary based on the complexity of the transaction.
+        // const overrides = {
+        //     gasLimit: 5000000
+        // };
 
-    if (!newSchemaUID || typeof newSchemaUID !== 'string' || !newSchemaUID.startsWith('0x')) {
-        throw new Error(`Schema registration transaction failed or returned an invalid UID: ${newSchemaUID}`);
+        const overrides = {}
+        console.log(`Using overrides: ${JSON.stringify(overrides)}`);
+
+        const transaction = await schemaRegistry.register({
+            schema: schema,
+            resolverAddress: resolverAddress ?? ethers.ZeroAddress, // Use ZeroAddress if no resolver
+            revocable: revocable,
+        }, overrides); // Pass overrides here
+
+        console.log("Waiting for transaction confirmation...");
+        const receipt = await transaction.wait(); // Wait for the receipt instead
+        console.log("Transaction confirmation received.");
+
+
+        // Ensure receipt is valid and transaction succeeded
+        if (!receipt || transaction.receipt?.status === 0) {
+            console.error("Transaction failed on-chain. Receipt:", receipt);
+            throw new Error(`Schema registration transaction failed on-chain (status ${transaction.receipt?.status}). Hash: ${transaction.receipt?.hash}`);
+        }
+
+        // We are sure registeredEvent is not null here and corresponds to the Registered event
+        const SchemaUID = receipt
+
+        if (!SchemaUID || typeof SchemaUID !== 'string' || !SchemaUID.startsWith('0x')) {
+            console.error("Extracted UID is invalid:", SchemaUID);
+            throw new Error(`Schema registration transaction succeeded but returned an invalid UID: ${SchemaUID}`);
+        }
+
+        console.log("Schema registered successfully!");
+        console.log("New Schema UID:", SchemaUID);
+        console.log(`View schema at: https://sepolia.easscan.org/schema/view/${SchemaUID}`);
+
+        return SchemaUID;
+
+    } catch (error) {
+        console.error("\n--- Error during schema registration --- ");
+
+        let errorMessage = "Schema registration failed";
+
+        if (error instanceof Error) {
+            // Check if isError 
+            if (isError(error, "CALL_EXCEPTION")) {
+                console.error(`Type: ${error.code} (Transaction Reverted)`);
+                console.error("Action:", error.action);
+                console.error("Reason:", error.reason);
+                console.error("Transaction:", error.transaction);
+
+                if (error.action === "estimateGas") {
+                    console.error("Transaction might have run out of gas. Consider increasing the gas.");
+                    console.error("Note: Any unused gas will be refunded. See EIP-1559 for details.");
+                }
+            }
+            else {
+                console.error(`Type: ${error}`);
+                if ('action' in error) console.error("Action:", error.action);
+                if ('reason' in error) console.error("Reason:", error.reason);
+                if ('transaction' in error) console.error("Transaction:", error.transaction);
+            }
+
+            // Log the full error object for detailed inspection
+            console.error("Full Error Object:", JSON.stringify(error, null, 2));
+        }
+
+        throw new Error(errorMessage); // Re-throw a more informative error
     }
-
-    // Removed the log parsing logic as wait() is assumed to return the UID directly
-
-    console.log("Schema registered successfully!");
-    console.log("New Schema UID:", newSchemaUID);
-    console.log(`View schema at: https://sepolia.easscan.org/schema/view/${newSchemaUID}`);
-
-    return newSchemaUID;
 }
 
 /**
@@ -70,7 +187,7 @@ export async function registerSchema(
  * @param uid - The UID of the schema to fetch.
  * @returns {Promise<SchemaRecord | null>} The schema record object, or null if not found.
  */
-export async function getSchema(uid: string): Promise<SchemaRecord | null> {
+export async function fetchSchema(uid: string): Promise<SchemaRecord | null> {
     // Instantiate SchemaRegistry directly with its address
     const schemaRegistry = new SchemaRegistry(EASSchemaRegistryAddress);
     const { provider } = getProviderSigner(); // Need provider for read operations
@@ -96,3 +213,4 @@ export async function getSchema(uid: string): Promise<SchemaRecord | null> {
         throw error;
     }
 }
+

--- a/src/examples/fetch-schema.ts
+++ b/src/examples/fetch-schema.ts
@@ -1,4 +1,4 @@
-import { getSchema } from "../eas-schema";
+import { fetchSchema } from "../eas-schema";
 
 // Example usage of the getSchema function
 
@@ -17,7 +17,7 @@ async function runExampleGetSchema() {
         console.log(`\nAttempting to fetch schema with UID: ${schemaUID}...`);
 
         // Fetch the schema
-        const schemaRecord = await getSchema(schemaUID);
+        const schemaRecord = await fetchSchema(schemaUID);
 
         if (schemaRecord) {
             console.log("\nSchema fetched successfully:");


### PR DESCRIPTION
This feature updates is to address EAS SDK's lack of built-in functionality to check if an existing schema exists before registering.

I found out that when registering a schema when it already existed, will fail and there's no messaging to alert a user to this. You can calculate the UID of a schema by using the `Keccak256` hashing algorithm. There is no documentation or source info that calls this specifically so you really have to dig around for it.  I only found this out while chatting with ChatGPT.

Sources: [1](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/contracts/SchemaRegistry.sol), [2](https://docs.ethers.org/v5/api/utils/hashing/), [3](https://docs.attest.org/docs/tutorials/create-a-schema)  

See function `checkExistingSchema` for more details.

I also ran into a problem with submitting attestations the the required gas fee was more than the built default value of 21,000. 
I added an override section that's currently commented out than can be modified if you run into situations like what I mentioned.

``` typescript

        // Setting up the transaction overrides. This is optional and can be adjusted.
        // If you're experiencing hangs with the transaction, it might help to adjust
        // the gas limit or other parameters. The default gas limit is usually sufficient,
        // but you can specify it explicitly if needed.

        // Uncomment the following line to set an explicit gas limit if needed and other overrides
        // the default gas limit is 21000 for simple transactions, but it can vary based on the complexity of the transaction.
        // const overrides = {
        //     gasLimit: 5000000
        // };
```

I also changed the name of the `getSchema` function to `fetchSchema` as not to overlap with the existing naming in EAS SDK. Updated the codebase as needed with this naming change.
 
