### PR TITLE
ProofMode PoC Extension: Proof Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# sample data directory
+sample-data/*
+

--- a/README.md
+++ b/README.md
@@ -356,9 +356,15 @@ When using ProofMode, ensure you select location mode at a minimum.
 > **Note:**
 Given that the NOTARY and C2PA  proof type classifications aren't yet implemented, the workflow will only recognize NETWORK as an additional proof type classification.
 
-Place your ProofMode zip file (format: `Test_PM-*.zip`) containing an image and its proof.json file in the `sample-data` directory of this repository.
+Run the following command from the root directory to create the `sample-data` directory:
 
-Then, run the following command from the root directory:
+```bash
+mkdir -p sample-data
+```
+
+Then, place your ProofMode zip file (format: `Test_PM-*.zip`) containing an image and its proof.json file in the `sample-data` directory of this repository.
+
+Finally, run the following command from the root directory:
 
 ```bash
 yarn workflow:proofmode

--- a/README.md
+++ b/README.md
@@ -318,19 +318,47 @@ Under the `src/workflows` directory, you'll find `workflow-proofmode.ts`, which 
 
 The workflow performs the following steps:
 
-1. Registers a schema designed for ProofMode metadata if not already registered
-2. Locates and extracts a ProofMode zip file containing a media file with verification metadata
-3. Processes the image and its associated proof.json file to extract geolocation data, timestamps, and other verification details
-4. Creates an on-chain attestation with the extracted metadata
-5. The attestation provides a tamper-evident, blockchain-backed verification of when and where the media was captured
+1. **Schema Registration**: Ensures a schema designed for ProofMode metadata exists, creating one if necessary
+2. **Metadata Extraction**: Locates and extracts a ProofMode zip file containing media with verification metadata
+3. **Metadata Processing**: Parses the extracted proof.json file to extract:
+   - Geolocation data (latitude/longitude coordinates)
+   - Timestamps of when the media was captured
+   - Device information and identifiers
+   - Network details and connectivity information
+   - Other verification details organized by proof type
+4. **Proof Type Classification**: Categorizes verification data into different proof types:
+   - BASIC: Core location and device information
+   - NETWORK: Cell information
+  
+> **Note:**
+The NOTARY and C2PA proof type classifications aren't yet implemented.
+
+
+5. **On-chain Attestation**: Creates a tamper-evident, blockchain-backed verification record with the extracted metadata
+
+> **Note:**
+The current workflow extracts metadata from ProofMode files but doesn't include the actual images in the EAS schema. Only the metadata and proofs about the images are stored on-chain.
+
+
+### Key Features
+
+- **Automatic Schema Management**: Checks for existing schemas before registration to avoid duplication
+- **Rich Metadata Extraction**: Extracts and preserves comprehensive verification data
+- **Flexible Proof Types**: The system can handle multiple types of proofs from the same media file
+- **Self-contained Verification**: Proof types are preserved as structured data in the attestation
 
 This proof of concept is particularly valuable for applications requiring verified media evidence, such as journalism, human rights documentation, legal evidence collection, and scientific field research where the authenticity and provenance of media are critical.
 
 **To run this workflow**
 
-First, place your ProofMode zip file (format: `Test_PM-*.zip`) containing an image and its proof.json file in the `src/workflows` directory.
+When using ProofMode, ensure you select location mode at a minimum.
 
-Then, run the following command from the root directory of this repository:
+> **Note:**
+Given that the NOTARY and C2PA  proof type classifications aren't yet implemented, the workflow will only recognize NETWORK as an additional proof type classification.
+
+Place your ProofMode zip file (format: `Test_PM-*.zip`) containing an image and its proof.json file in the `sample-data` directory of this repository.
+
+Then, run the following command from the root directory:
 
 ```bash
 yarn workflow:proofmode

--- a/src/workflows/workflow-proofmode.ts
+++ b/src/workflows/workflow-proofmode.ts
@@ -241,16 +241,23 @@ export async function runProofModeWorkflow(): Promise<void> {
         console.log(`Using Schema UID: ${schemaUID}`);
 
         // 2. Find and extract the ProofMode zip file
-        const zipFile = fs.readdirSync(__dirname).find(file => file.startsWith('Test_PM-') && file.endsWith('.zip'));
+
+        // check if the sample-data directory exists
+        if (!fs.existsSync(path.join(__dirname, '..', '..', 'sample-data'))) {
+            throw new Error('Sample data directory not found. Please ensure it exists.');
+        }
+
+        const sampleDataDir = path.join(__dirname, '..', '..', 'sample-data');
+        const zipFile = fs.readdirSync(sampleDataDir).find(file => file.startsWith('Test_PM-') && file.endsWith('.zip'));
         if (!zipFile) {
             throw new Error('No ProofMode zip file found. Please ensure a Test_PM-*.zip file is available.');
         }
-        const zipFilePath = path.join(__dirname, zipFile);
+        const zipFilePath = path.join(sampleDataDir, zipFile);
         console.log(`Found ProofMode zip file: ${zipFilePath}`);
-        
+
         // Create a directory to extract the zip file to (use the same name as the zip file without the .zip extension)
-        const extractDir = path.join(__dirname, zipFile.replace('.zip', ''));
-        
+        const extractDir = path.join(sampleDataDir, zipFile.replace('.zip', ''));
+
         // Extract the zip file
         extractZipFile(zipFilePath, extractDir);
 


### PR DESCRIPTION
**ProofMode PoC Extension: Proof Types**

feat: 
- Design extraction mechanism to create protocol-compatible "proofs" from ProofMode data
- Format proofs to ensure compatibility with location protocol specification
- Add validation to ensure ProofMode entries contain at least lat/long data
- Add infrastructure to create proofs of different types (BASIC, NETWORK, NOTARY, C2PA)
- Implement multiple proof type support (BASIC, NETWORK)
- Refactor workflow with enhanced schema registration to support categorized proof evidence

docs:
- Update ProofMode workflow documentation with implementation details